### PR TITLE
Fix IPv6 header size in BPF parser

### DIFF
--- a/scone_ebpf.c
+++ b/scone_ebpf.c
@@ -110,7 +110,7 @@ static __always_inline u64 check_quic(void *data, void *data_end) {
     struct iphdr *ip = (void *)eth + sizeof(*eth);
     struct ipv6hdr *ip6 = (void *)ip;
     struct udphdr *udp = (void *)ip + sizeof(*ip);
-    if (ipproto == ETH_P_IPV6) udp = (void *)ip6 + sizeof(*ip);
+    if (ipproto == ETH_P_IPV6) udp = (void *)ip6 + sizeof(*ip6);
     char *quic = (char *)udp + sizeof(*udp);
     u16 port;
 


### PR DESCRIPTION
## Summary
- fix `check_quic` IPv6 header offset

## Testing
- `clang -O2 -target bpf -c scone_ebpf.c -o scone_ebpf.o` *(fails: `asm/types.h` file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68864ebfb9c08324baf99adebef62edb